### PR TITLE
[김동규] #9-유저 회원가입 API 테스트코드 작성

### DIFF
--- a/users/tests.py
+++ b/users/tests.py
@@ -1,3 +1,167 @@
-from django.test import TestCase
+import json
 
-# Create your tests here.
+from rest_framework.status import HTTP_201_CREATED, HTTP_400_BAD_REQUEST
+from rest_framework.test import APITestCase
+
+from users.models import User
+
+
+class UserSignUpTest(APITestCase):
+    """회원가입 구현 View
+
+    Writer: 김동규
+    Date: 2022-07-05
+
+    유저 회원가입의 성공/실패 경우를 테스트 합니다.
+
+    param :
+        email       - 이메일 주소
+        nickname    - 닉네임
+        password    - 비밀번호
+    """
+
+    maxDiff = None
+
+    @classmethod
+    def setUpTestData(cls):
+        User.objects.create_user(email='test02@gmail.com', nickname='DGK02', password='DGKtest12345!!')
+
+    # success test
+    def test_success_user_signup(self):
+        data = {'email': 'test01@gmail.com', 'nickname': 'DGK01', 'password': 'DGKtest12345!!'}
+
+        response = self.client.post('/users/signup', data=json.dumps(data), content_type='application/json')
+
+        self.assertEqual(response.status_code, HTTP_201_CREATED)
+        self.assertEqual(response.json(), {'email': 'test01@gmail.com', 'nickname': 'DGK01'})
+
+    # fail test
+    def test_fail_user_signup_due_to_email_format_validation(self):
+        data = {'email': 'test01@gmail', 'nickname': 'DGK01', 'password': 'DGKtest12345!!'}
+
+        response = self.client.post('/users/signup', data=json.dumps(data), content_type='application/json')
+
+        self.assertEqual(response.status_code, HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json(), {'email': ['올바른 이메일 주소를 입력하세요.']})
+
+    def test_fail_user_signup_due_to_already_existed_email(self):
+        data = {'email': 'test02@gmail.com', 'nickname': 'DGK01', 'password': 'DGKtest12345!!'}
+
+        response = self.client.post('/users/signup', data=json.dumps(data), content_type='application/json')
+
+        self.assertEqual(response.status_code, HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json(), {'email': ['user의 email은/는 이미 존재합니다.']})
+
+    def test_fail_user_signup_due_to_email_required(self):
+        data = {'nickname': 'DGK01', 'password': 'DGKtest12345!!'}
+
+        response = self.client.post('/users/signup', data=json.dumps(data), content_type='application/json')
+
+        self.assertEqual(response.status_code, HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json(), {'email': ['필수 항목입니다.']})
+
+    def test_fail_user_signup_due_to_already_existed_email_n_nickname(self):
+        data = {'email': 'test02@gmail.com', 'nickname': 'DGK02', 'password': 'DGKtest12345!!'}
+
+        response = self.client.post('/users/signup', data=json.dumps(data), content_type='application/json')
+
+        self.assertEqual(response.status_code, HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.json(), {'email': ['user의 email은/는 이미 존재합니다.'], 'nickname': ['user의 nickname은/는 이미 존재합니다.']}
+        )
+
+    def test_fail_user_signup_due_to_nickname_required(self):
+        data = {'email': 'test01@gmail.com', 'password': 'DGKtest12345!!'}
+
+        response = self.client.post('/users/signup', data=json.dumps(data), content_type='application/json')
+
+        self.assertEqual(response.status_code, HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json(), {'nickname': ['필수 항목입니다.']})
+
+    def test_fail_user_signup_due_to_already_existed_nickname(self):
+        data = {'email': 'test01@gmail.com', 'nickname': 'DGK02', 'password': 'DGKtest12345!!'}
+
+        response = self.client.post('/users/signup', data=json.dumps(data), content_type='application/json')
+
+        self.assertEqual(response.status_code, HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json(), {'nickname': ['user의 nickname은/는 이미 존재합니다.']})
+
+    def test_fail_user_signup_due_to_password_gt_20_digit(self):
+        data = {
+            'email': 'test01@gmail.com',
+            'nickname': 'DGK01',
+            'password': 'DGKtest12345!!DGKtest12345!!',
+        }
+
+        response = self.client.post('/users/signup', data=json.dumps(data), content_type='application/json')
+
+        self.assertEqual(response.status_code, HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json(), {'password': ['올바른 비밀번호를 입력하세요.']})
+
+    def test_fail_user_signup_due_to_password_lt_8_digit(self):
+        data = {
+            'email': 'test01@gmail.com',
+            'nickname': 'DGK01',
+            'password': 'DGKtest',
+        }
+
+        response = self.client.post('/users/signup', data=json.dumps(data), content_type='application/json')
+
+        self.assertEqual(response.status_code, HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json(), {'password': ['올바른 비밀번호를 입력하세요.']})
+
+    def test_fail_user_signup_due_to_password_required(self):
+        data = {'email': 'test01@gmail.com', 'nickname': 'DGK01'}
+
+        response = self.client.post('/users/signup', data=json.dumps(data), content_type='application/json')
+
+        self.assertEqual(response.status_code, HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json(), {'password': ['필수 항목입니다.']})
+
+    def test_fail_user_signup_due_to_password_no_small_letters(self):
+        data = {
+            'email': 'test01@gmail.com',
+            'nickname': 'DGK01',
+            'password': 'DGKTEST123!!',
+        }
+
+        response = self.client.post('/users/signup', data=json.dumps(data), content_type='application/json')
+
+        self.assertEqual(response.status_code, HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json(), {'password': ['올바른 비밀번호를 입력하세요.']})
+
+    def test_fail_user_signup_due_to_password_no_capital_letters(self):
+        data = {
+            'email': 'test01@gmail.com',
+            'nickname': 'DGK01',
+            'password': 'dgktest123!!',
+        }
+
+        response = self.client.post('/users/signup', data=json.dumps(data), content_type='application/json')
+
+        self.assertEqual(response.status_code, HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json(), {'password': ['올바른 비밀번호를 입력하세요.']})
+
+    def test_fail_user_signup_due_to_password_no_special_letters(self):
+        data = {
+            'email': 'test01@gmail.com',
+            'nickname': 'DGK01',
+            'password': 'DGKtest123',
+        }
+
+        response = self.client.post('/users/signup', data=json.dumps(data), content_type='application/json')
+
+        self.assertEqual(response.status_code, HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json(), {'password': ['올바른 비밀번호를 입력하세요.']})
+
+    def test_fail_user_signup_due_to_password_unexpected_special_letters(self):
+        data = {
+            'email': 'test01@gmail.com',
+            'nickname': 'DGK01',
+            'password': 'DGKtest123!!./',
+        }
+
+        response = self.client.post('/users/signup', data=json.dumps(data), content_type='application/json')
+
+        self.assertEqual(response.status_code, HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json(), {'password': ['올바른 비밀번호를 입력하세요.']})


### PR DESCRIPTION
<!--PR 제목 : [ 이름 ] # 이슈번호 - 구현 내용-->

# 구현 목표
<!-- 이슈 번호 맵핑해주세요. 간단한 요약을 해주세요.-->
- 유저 회원가입 테스트코드 작성(Total 14 Test Case)

# 변경 사항
<!--관련 없는 내용을 지워주세요-->

- [x] 기능 추가


<!--⬇ 변경사항을 자세히 작성합니다. ⬇-->
- 유저 회원가입 API의 성공 case를 테스트합니다.
- 유저 회원가입 API의 실패 case를 테스트합니다.
   - email field로 실패하는 경우
   - nickname field로 실패하는 경우
   - password field로 실패하는 경우


# 테스트 여부
<!--테스트 통과 여부를 체크해주세요-->
- [x] TEST 

# 스크린샷 
<!--필요한 경우 첨부합니다-->
<img width="859" alt="스크린샷 2022-07-06 15 13 43" src="https://user-images.githubusercontent.com/89829943/177482165-ea26924e-4a4c-4c5c-9f3d-7bf1b0821050.png">

